### PR TITLE
improves the ordering of tasks

### DIFF
--- a/src/tasks/task.rs
+++ b/src/tasks/task.rs
@@ -88,8 +88,16 @@ impl ::std::cmp::PartialOrd for Task {
 
 impl ::std::cmp::Ord for Task {
     fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
-        if self.inner.due_date != other.inner.due_date {
-            return self.inner.due_date.cmp(&other.inner.due_date);
+        if self.finished {
+           if self.inner.finish_date != other.inner.finish_date {
+               return self.inner.finish_date.cmp(&other.inner.finish_date).reverse();
+           }
+        } else if self.inner.due_date != other.inner.due_date {
+            if self.inner.due_date.is_none() || other.inner.due_date.is_none() {
+                return self.inner.due_date.cmp(&other.inner.due_date).reverse();
+            } else {
+                return self.inner.due_date.cmp(&other.inner.due_date);
+            }
         }
 
         if self.inner.priority != other.inner.priority {

--- a/src/widgets/tasks.rs
+++ b/src/widgets/tasks.rs
@@ -28,7 +28,6 @@ impl Tasks {
 
             let mut sorted_tasks = tasks.to_owned();
             sorted_tasks.sort();
-            //sorted_tasks.reverse();
 
             for task in &sorted_tasks {
                 let child = self.list_box.add_widget::<super::Task>(task.clone());

--- a/src/widgets/tasks.rs
+++ b/src/widgets/tasks.rs
@@ -28,7 +28,7 @@ impl Tasks {
 
             let mut sorted_tasks = tasks.to_owned();
             sorted_tasks.sort();
-            sorted_tasks.reverse();
+            //sorted_tasks.reverse();
 
             for task in &sorted_tasks {
                 let child = self.list_box.add_widget::<super::Task>(task.clone());


### PR DESCRIPTION
Order the tasks in the all tasks list by the earliest due date first, except for finished tasks where the latest finish date is first.

Fixes #34.